### PR TITLE
Setup express

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
 		'import/prefer-default-export': 0,
 		'no-undef': 0,
 		'prefer-arrow-callback': ['error'],
-		'implicit-arrow-linebreak': ['error'],
+		'implicit-arrow-linebreak': 0,
 		'no-useless-constructor': ['error'],
 		semi: ['error', 'never'],
 		'eol-last': 0,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,9 @@ import reminderController from '@controllers/reminder.controller'
 
 const router = Router()
 
+router.get('/api/ping', (req, res) =>
+	res.json({ message: 'Hello! You have found the zc_plugin_reminder api' })
+)
 router.route('/reminders').get(reminderController.create)
 
 export default router

--- a/src/shared/http/server.js
+++ b/src/shared/http/server.js
@@ -26,4 +26,8 @@ app.use((req, res, next) => {
 
 app.use(errorHandler)
 
+app.all('*', async (req, res) => {
+	res.redirect('/')
+})
+
 export default app


### PR DESCRIPTION
This PR is the final setup of the express and react app hosted on [Reminder-plugin](https://reminders.zuri.chat). You can access the API on [API](https://reminders.zuri.chat/api/reminders) to test.
