### PR TITLE
Design System

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
 	extends: ['plugin:prettier/recommended', 'plugin:react/recommended'],
 	rules: {
 		'prettier/prettier': ['error', { endOfLine: 'auto' }],
-		'indent': ['error', 2],
+		indent: ['error', 2],
 		'arrow-body-style': 'off',
 		'prefer-const': ['error'],
 		'no-var': ['error'],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
 		"web-vitals": "^1.0.1"
 	},
 	"scripts": {
-		"start": "set TAILWIND_MODE=watch&craco start",
+		"start": "craco start",
 		"build": "craco build",
 		"test": "craco test",
 		"eject": "react-scripts eject",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,16 +2,8 @@ import React from 'react'
 
 const App = () => {
 	return (
-		<div className="flex flex-col items-center justify-center h-screen text-center ">
-			<header className="text-3xl text-cra-primary font-craFont">
-				<h1>Zuri Chat Reminder Plugin</h1>
-				<p>
-					Reminder plugin for the open-source{' '}
-					<a href="https://zuri.chat" className="text-cra-link">
-						Zuri Chat
-					</a>
-				</p>
-			</header>
+		<div className="flex flex-col items-center justify-center h-screen text-center">
+			App
 		</div>
 	)
 }

--- a/frontend/src/__test__/App.test.jsx
+++ b/frontend/src/__test__/App.test.jsx
@@ -1,13 +1,7 @@
 import React from 'react'
 import App from '../App'
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 test('<App /> renders without crashing', () => {
 	render(<App />)
-})
-
-test('link to zuri chat rendered', () => {
-	render(<App />)
-	const linkElement = screen.getByRole('link', { name: /zuri chat/i })
-	expect(linkElement).toBeInTheDocument()
 })

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,34 +1,34 @@
 module.exports = {
-	mode: 'jit',
 	purge: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
 	darkMode: false, // or 'media' or 'class'
 	theme: {
 		extend: {
-			backgroundColor: {
-				cra: {
-					primary: '#282c34',
+			colors: {
+				brand: {
+					primary: '#00B87C',
+					secondary: '#1A61DB',
+					accent: '#B8003C',
+					text: {
+						header: '#242424',
+						body: '#3A3A3A',
+						leftNav: '#999999',
+						time: '#DADADA',
+						lightIcon: '#BEBEBE',
+					},
+					error: '#F40101',
+					bg: {
+						lightGrey: '#F6F6F6',
+						white: '#FFFFFF',
+					},
+					success: '#008B5E',
+					avatar: {
+						pink: '#F7E0FF',
+						yellow: '#F8FFCD',
+						red: '#FFF0F0',
+						green: '#ACFFE6',
+						blue: '#E3EEFF',
+					},
 				},
-			},
-			textColor: {
-				cra: {
-					link: '#61dafb',
-					primary: '#282c34',
-				},
-			},
-			fontFamily: {
-				craFont: [
-					'-apple - system',
-					'BlinkMacSystemFont',
-					'Segoe UI',
-					'Roboto',
-					'Oxygen',
-					'Ubuntu',
-					'Cantarell',
-					'Fira Sans',
-					'Droid Sans',
-					'Helvetica Neue',
-					'sans - serif',
-				],
 			},
 		},
 	},


### PR DESCRIPTION
Colors have been added to the tailwind config according to [the Figma doc](https://www.figma.com/file/t7TK0AdgKRGqcJCFeq5Fiv/Team-Darwin-Mock-Up-Submission?node-id=498%3A2445). 

Tailwind has also been updated not to use JIT. \
This is a breaking change, update your style declarations to use the defined colors under the brand key. You can no longer use the bracket notation for arbitrary values. i.e. bg-[#A1A1A1]

For example, styling a button to use the primary color in the design system would be\
`bg-brand-primary`.  Update your styling accordingly
